### PR TITLE
Use origin/master as benchmark baseline

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -23,7 +23,6 @@ jobs:
                       "OMP_NUM_THREADS" => "1",
                   ),
               ),
-              "origin/benchmarks",
           );
           '
       - name: Post results


### PR DESCRIPTION
## Commit Message
Use origin/master as benchmark baseline (#11)

This is something I forgot to remove in
242a4b00e9107df2ebbf5a9216cf607b61a75354 (#8).