### PR TITLE
Use `n = 2^20` in bench_findfirst.jl

### DIFF
--- a/benchmark/bench_findfirst.jl
+++ b/benchmark/bench_findfirst.jl
@@ -6,7 +6,7 @@ using ThreadsX
 
 Random.seed!(1234)
 
-n = 2^18
+n = 2^20
 
 suite = BenchmarkGroup()
 


### PR DESCRIPTION
## Commit Message
Use `n = 2^20` in bench_findfirst.jl (#53)

It's hard to detect performance improvements with `n = 2^18`. Compare:
`n = 2^18`: https://github.com/tkf/ThreadsX.jl/pull/48#issuecomment-596873759
`n = 2^20`: https://github.com/tkf/ThreadsX.jl/pull/52#issuecomment-596874313
