### PR TITLE
Fix a usage of at-inbounds

### DIFF
--- a/src/map.jl
+++ b/src/map.jl
@@ -41,7 +41,7 @@ ThreadsX.foreach(
     kw...,
 ) where {N} =
     ThreadsX.foreach(eachindex(array, arrays...); kw...) do i
-        @inbounds f(array[i], map(x -> x[i], arrays)...)
+        f((@inbounds array[i]), map(x -> (@inbounds x[i]), arrays)...)
     end
 
 #=


### PR DESCRIPTION
Looking at lowering, it looks like this macro doesn't handle anonymous functions.