### PR TITLE
Use create-pull-request v2

### DIFF
--- a/.github/workflows/pkg-update.yml
+++ b/.github/workflows/pkg-update.yml
@@ -20,11 +20,15 @@ jobs:
           target: create-pull-request/pkg-update-2
 
       # Since create-pull-request does not like when the current
-      # branch is the target branch, checkout a temporary one.
+      # branch is the target branch, checkout master.
       # https://github.com/JuliaFolds/Transducers.jl/pull/167
-      - name: "Checkout a temporary branch"
-        run:
-          git checkout -b create-pull-request/pkg-update-tmp
+      - name: "Checkout and merge to master"
+        run: |
+          if [ "$(git rev-parse --abbrev-ref HEAD)" != "master" ]
+          then
+              git checkout master
+              git merge --ff-only create-pull-request/pkg-update-2
+          fi
 
       # https://github.com/tkf/julia-update-manifests
       - name: Update */Manifest.toml

--- a/.github/workflows/pkg-update.yml
+++ b/.github/workflows/pkg-update.yml
@@ -16,17 +16,31 @@ jobs:
           ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
           # https://github.com/peter-evans/create-pull-request/blob/master/docs/concepts-guidelines.md#push-using-ssh-deploy-keys
 
-      - name: "Fetch branches"
-        run: |
-          git fetch --unshallow origin master
-          git fetch origin create-pull-request/pkg-update-2 || true
-          git checkout -B master origin/master
-
-      # https://github.com/tkf/julia-merge-except-manifests
       - name: 'Merge master to create-pull-request/pkg-update-2'
-        uses: tkf/julia-merge-except-manifests@dev
-        with:
-          target: create-pull-request/pkg-update-2
+        run: |
+          base="master"
+          target="create-pull-request/pkg-update-2"
+
+          git_fetch_origin() {
+              git fetch --unshallow origin "$1" || git fetch origin "$1"
+          }
+
+          set -ex
+
+          git_fetch_origin "refs/heads/$base:refs/remotes/origin/$base"
+          git checkout -B "$base" "origin/$base"
+
+          git_fetch_origin "refs/heads/$target:refs/remotes/origin/$target" || exit 0
+          git checkout -B "$target" "origin/$target"
+          git merge --strategy=ours --no-commit "$base"
+          find . -type d -name .git -prune -o -type f -print0 | xargs --null rm -rf
+          git checkout "$base" -- .
+          git ls-tree -r --name-only "origin/$target" | grep -F Manifest.toml \
+              | xargs git checkout "origin/$target" --
+          git ls-tree -r --name-only "origin/$target" | grep -F Manifest.toml \
+              | xargs git add -f --
+          git add .
+          git commit -m "Merge branch '$base'" || exit 0
 
       # Since create-pull-request does not like when the current
       # branch is the target branch, checkout master.

--- a/.github/workflows/pkg-update.yml
+++ b/.github/workflows/pkg-update.yml
@@ -60,9 +60,6 @@ jobs:
           version: '1.4'
           projects: test/environments/main benchmark docs
 
-      - name: "spam"
-        run: "echo spam > src/ThreadsX.jl"
-
       # https://github.com/peter-evans/create-pull-request
       # https://github.com/marketplace/actions/create-pull-request
       - name: Create Pull Request

--- a/.github/workflows/pkg-update.yml
+++ b/.github/workflows/pkg-update.yml
@@ -20,6 +20,7 @@ jobs:
         run: |
           git fetch --unshallow origin master
           git fetch origin create-pull-request/pkg-update-2 || true
+          git checkout -B master origin/master
 
       # https://github.com/tkf/julia-merge-except-manifests
       - name: 'Merge master to create-pull-request/pkg-update-2'

--- a/.github/workflows/pkg-update.yml
+++ b/.github/workflows/pkg-update.yml
@@ -18,7 +18,7 @@ jobs:
 
       # https://github.com/tkf/julia-merge-except-manifests
       - name: 'Merge master to create-pull-request/pkg-update-2'
-        uses: tkf/julia-merge-except-manifests@v1
+        uses: tkf/julia-merge-except-manifests@dev
         with:
           target: create-pull-request/pkg-update-2
 

--- a/.github/workflows/pkg-update.yml
+++ b/.github/workflows/pkg-update.yml
@@ -14,10 +14,17 @@ jobs:
       - uses: actions/checkout@v2
 
       # https://github.com/tkf/julia-merge-except-manifests
-      - name: 'Merge master to create-pull-request/pkg-update'
+      - name: 'Merge master to create-pull-request/pkg-update-2'
         uses: tkf/julia-merge-except-manifests@v1
         with:
-          target: create-pull-request/pkg-update
+          target: create-pull-request/pkg-update-2
+
+      # Since create-pull-request does not like when the current
+      # branch is the target branch, checkout a temporary one.
+      # https://github.com/JuliaFolds/Transducers.jl/pull/167
+      - name: "Checkout a temporary branch"
+        run:
+          git checkout -b create-pull-request/pkg-update-tmp
 
       # https://github.com/tkf/julia-update-manifests
       - name: Update */Manifest.toml
@@ -29,7 +36,7 @@ jobs:
       # https://github.com/peter-evans/create-pull-request
       # https://github.com/marketplace/actions/create-pull-request
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v1
+        uses: peter-evans/create-pull-request@v2
         with:
           token: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
           commit-message: Update */Manifest.toml
@@ -46,8 +53,7 @@ jobs:
           # --- Commit Message and squash Method
           # https://doc.mergify.io/actions.html#commit-message-and-squash-method
           labels: no changelog
-          branch: create-pull-request/pkg-update
-          branch-suffix: none
+          branch: create-pull-request/pkg-update-2
           base: master
       - name: Check output environment variable
         run: echo "Pull Request Number - ${{ env.PULL_REQUEST_NUMBER }}"

--- a/.github/workflows/pkg-update.yml
+++ b/.github/workflows/pkg-update.yml
@@ -12,6 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          # https://github.com/peter-evans/create-pull-request/blob/master/docs/concepts-guidelines.md#push-using-ssh-deploy-keys
 
       # https://github.com/tkf/julia-merge-except-manifests
       - name: 'Merge master to create-pull-request/pkg-update-2'
@@ -45,7 +48,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v2
         with:
-          token: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: Update */Manifest.toml
           title: 'Update */Manifest.toml'
           body: |

--- a/.github/workflows/pkg-update.yml
+++ b/.github/workflows/pkg-update.yml
@@ -37,6 +37,9 @@ jobs:
           version: '1.4'
           projects: test/environments/main benchmark docs
 
+      - name: "spam"
+        run: "echo spam > src/ThreadsX.jl"
+
       # https://github.com/peter-evans/create-pull-request
       # https://github.com/marketplace/actions/create-pull-request
       - name: Create Pull Request

--- a/.github/workflows/pkg-update.yml
+++ b/.github/workflows/pkg-update.yml
@@ -16,6 +16,11 @@ jobs:
           ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
           # https://github.com/peter-evans/create-pull-request/blob/master/docs/concepts-guidelines.md#push-using-ssh-deploy-keys
 
+      - name: "Fetch branches"
+        run: |
+          git fetch --unshallow origin master
+          git fetch origin create-pull-request/pkg-update-2 || true
+
       # https://github.com/tkf/julia-merge-except-manifests
       - name: 'Merge master to create-pull-request/pkg-update-2'
         uses: tkf/julia-merge-except-manifests@dev


### PR DESCRIPTION
Trying to fix https://github.com/tkf/ThreadsX.jl/pull/100#issuecomment-650712786

## Commit Message
Use create-pull-request v2 (#112)

Using SSH-based configuration (which quires create-pull-request v2) so
that (hopefully) commits from this workflow will trigger actions.
With `ssh-key` is passed to actions/checkout@v2, git commands cannot
be used inside docker anymore (tkf/julia-merge-except-manifests@v1).
So, just inlining the script for now.
