### PR TITLE
Require SplittablesBase 0.1.8

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,7 @@ ConstructionBase = "0.1.0, 1.0"
 InitialValues = "0.2"
 Referenceables = "0.1"
 Setfield = "0.3, 0.4, 0.5, 0.6"
-SplittablesBase = "0.1.1"
+SplittablesBase = "0.1.8"
 Transducers = "0.4.25"
 julia = "1"
 


### PR DESCRIPTION
To really fix `foreach(f, other arguments..., product(A, B))` (#113).