### PR TITLE
Use custom token in pkg-update.yml

### DIFF
--- a/.github/workflows/pkg-update.yml
+++ b/.github/workflows/pkg-update.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
           commit-message: Update */Manifest.toml
           title: 'Update */Manifest.toml'
           body: |


### PR DESCRIPTION
PRs (#117, #118) created without this didn't initiate the CIs while with the custom token it worked (#119).

This partially rolls back 7362ea86e20787f0337888ba55ee37880ced028a.