### PR TITLE
Revert "Let create-pull-request trigger CI via `on: push` (#121)"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,10 +4,6 @@ on:
   push:
     branches:
       - master
-      # Allowing CIs on push since create-pull-request requires `on:
-      # push` event to trigger the downstream actions:
-      # https://github.com/peter-evans/create-pull-request/issues/48#issuecomment-584209254
-      - create-pull-request/pkg-update
     tags: '*'
   pull_request:
 


### PR DESCRIPTION
Due to #121 tests pushed to `create-pull-request/pkg-update` are run
twice at the moment.  For example:

* https://github.com/tkf/ThreadsX.jl/pull/122/commits/728cfdf9d44ec4559d006e9c454c58d16c46e974
* https://github.com/tkf/ThreadsX.jl/runs/825017692
* https://github.com/tkf/ThreadsX.jl/runs/825017594

When tested with a branch that is not listed in `on: push` (#127, #128)
it looks like the first push does not trigger the CI while the
following push does.  Since a PR with `create-pull-request/pkg-update`
typically contains a lot of commits, missing the tests for the first
is not so bad.

So, reverting #121 (39d436cd7b7ba6dbd2185ba389f6dbda491316ab).