### PR TITLE
Use flags to control Aqua.test_all

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -7,5 +7,5 @@ Referenceables = "42d2dcc6-99eb-4e98-b66c-637b7d73030e"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-Aqua = "0.4.4"
+Aqua = "0.4.7"
 Documenter = "0.24"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -7,5 +7,5 @@ Referenceables = "42d2dcc6-99eb-4e98-b66c-637b7d73030e"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-Aqua = "0.4.1"
+Aqua = "0.4.4"
 Documenter = "0.24"

--- a/test/environments/main/Manifest.toml
+++ b/test/environments/main/Manifest.toml
@@ -8,11 +8,11 @@ version = "0.3.3"
 
 [[Aqua]]
 deps = ["Pkg", "Test"]
-git-tree-sha1 = "2c366fa12569d9232b5b7cfa37c36f3f1b2665b2"
+git-tree-sha1 = "abc44978086217dff515254ab01db5ca79f1d013"
 repo-rev = "master"
 repo-url = "https://github.com/JuliaTesting/Aqua.jl.git"
 uuid = "4c88cf16-eb10-579e-8560-4a9242c79595"
-version = "0.4.4-DEV"
+version = "0.4.7-DEV"
 
 [[ArgCheck]]
 git-tree-sha1 = "59c256cf71c3982484ae4486ee86a3d7da891dea"

--- a/test/environments/main/Manifest.toml
+++ b/test/environments/main/Manifest.toml
@@ -8,7 +8,7 @@ version = "0.3.3"
 
 [[Aqua]]
 deps = ["Pkg", "Test"]
-git-tree-sha1 = "abc44978086217dff515254ab01db5ca79f1d013"
+git-tree-sha1 = "ad018f5391dc5f82828a9efa88f7ace7ea63241c"
 repo-rev = "master"
 repo-url = "https://github.com/JuliaTesting/Aqua.jl.git"
 uuid = "4c88cf16-eb10-579e-8560-4a9242c79595"

--- a/test/environments/main/Manifest.toml
+++ b/test/environments/main/Manifest.toml
@@ -8,9 +8,11 @@ version = "0.3.3"
 
 [[Aqua]]
 deps = ["Pkg", "Test"]
-git-tree-sha1 = "0060f6e92605d768e1cb9e0ac3bd17966bc0209e"
+git-tree-sha1 = "2c366fa12569d9232b5b7cfa37c36f3f1b2665b2"
+repo-rev = "master"
+repo-url = "https://github.com/JuliaTesting/Aqua.jl.git"
 uuid = "4c88cf16-eb10-579e-8560-4a9242c79595"
-version = "0.4.3"
+version = "0.4.4-DEV"
 
 [[ArgCheck]]
 git-tree-sha1 = "59c256cf71c3982484ae4486ee86a3d7da891dea"

--- a/test/environments/main/Manifest.toml
+++ b/test/environments/main/Manifest.toml
@@ -8,11 +8,11 @@ version = "0.3.3"
 
 [[Aqua]]
 deps = ["Pkg", "Test"]
-git-tree-sha1 = "ad018f5391dc5f82828a9efa88f7ace7ea63241c"
+git-tree-sha1 = "ef5f638a83ec0099904ac1fe2cc254286e801a54"
 repo-rev = "master"
 repo-url = "https://github.com/JuliaTesting/Aqua.jl.git"
 uuid = "4c88cf16-eb10-579e-8560-4a9242c79595"
-version = "0.4.7-DEV"
+version = "0.4.7"
 
 [[ArgCheck]]
 git-tree-sha1 = "59c256cf71c3982484ae4486ee86a3d7da891dea"

--- a/test/environments/main/Project.toml
+++ b/test/environments/main/Project.toml
@@ -11,5 +11,5 @@ ThreadsX = "ac1d9e8a-700a-412c-b207-f0111f4b6c0d"
 Transducers = "28d57a85-8fef-5791-bfe6-a80928e7c999"
 
 [compat]
-Aqua = "0.4.1"
+Aqua = "0.4.4"
 Documenter = "0.24"

--- a/test/environments/main/Project.toml
+++ b/test/environments/main/Project.toml
@@ -11,5 +11,5 @@ ThreadsX = "ac1d9e8a-700a-412c-b207-f0111f4b6c0d"
 Transducers = "28d57a85-8fef-5791-bfe6-a80928e7c999"
 
 [compat]
-Aqua = "0.4.4"
+Aqua = "0.4.7"
 Documenter = "0.24"

--- a/test/test_aqua.jl
+++ b/test/test_aqua.jl
@@ -23,4 +23,8 @@ end
     Aqua.test_project_extras(ThreadsX)
 end
 
+@testset "Stale dependencies" begin
+    Aqua.test_stale_deps(ThreadsX)
+end
+
 end  # module

--- a/test/test_aqua.jl
+++ b/test/test_aqua.jl
@@ -12,6 +12,7 @@ Aqua.test_all(
     project_extras = true,
     stale_deps = true,
     deps_compat = true,
+    project_toml_formatting = true,
 )
 
 @testset "Method ambiguity" begin

--- a/test/test_aqua.jl
+++ b/test/test_aqua.jl
@@ -6,25 +6,16 @@ using Test
 
 # Default `Aqua.test_all(ThreadsX)` does not work due to ambiguities
 # in upstream packages.
+Aqua.test_all(
+    ThreadsX;
+    ambiguities = false,
+    project_extras = true,
+    stale_deps = true,
+    deps_compat = true,
+)
 
 @testset "Method ambiguity" begin
     Aqua.test_ambiguities(ThreadsX)
-end
-
-@testset "Unbound type parameters" begin
-    Aqua.test_unbound_args(ThreadsX)
-end
-
-@testset "Undefined exports" begin
-    Aqua.test_undefined_exports(ThreadsX)
-end
-
-@testset "Compare Project.toml and test/Project.toml" begin
-    Aqua.test_project_extras(ThreadsX)
-end
-
-@testset "Stale dependencies" begin
-    Aqua.test_stale_deps(ThreadsX)
 end
 
 end  # module


### PR DESCRIPTION
- [x] Merge #154 and then merge master to this PR
- [x] Release https://github.com/JuliaTesting/Aqua.jl/pull/35 and https://github.com/JuliaTesting/Aqua.jl/pull/34
- [x] Update test/Project.toml

## Commit Message
Use flags to control Aqua.test_all (#153)

Use flag-based configuration added in Aqua 0.4.7.