### PR TITLE
Update to Aqua 0.5

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -7,5 +7,5 @@ Referenceables = "42d2dcc6-99eb-4e98-b66c-637b7d73030e"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-Aqua = "0.4.7"
+Aqua = "0.5"
 Documenter = "0.24"

--- a/test/environments/main/Manifest.toml
+++ b/test/environments/main/Manifest.toml
@@ -8,9 +8,9 @@ version = "0.3.3"
 
 [[Aqua]]
 deps = ["Pkg", "Test"]
-git-tree-sha1 = "6775799bef0635cb3d96d2fdd0f145087edf8a73"
+git-tree-sha1 = "b28b1f08e814090ef35eec6ab974264b3a93c862"
 uuid = "4c88cf16-eb10-579e-8560-4a9242c79595"
-version = "0.4.9"
+version = "0.5.0"
 
 [[ArgCheck]]
 git-tree-sha1 = "59c256cf71c3982484ae4486ee86a3d7da891dea"

--- a/test/environments/main/Manifest.toml
+++ b/test/environments/main/Manifest.toml
@@ -8,7 +8,7 @@ version = "0.3.3"
 
 [[Aqua]]
 deps = ["Pkg", "Test"]
-git-tree-sha1 = "41c0492682754f55c2564577c92bafb8968090e3"
+git-tree-sha1 = "71bbfd1312212c06ebf8e97b9f3513603d42e001"
 repo-rev = "master"
 repo-url = "https://github.com/JuliaTesting/Aqua.jl.git"
 uuid = "4c88cf16-eb10-579e-8560-4a9242c79595"

--- a/test/environments/main/Manifest.toml
+++ b/test/environments/main/Manifest.toml
@@ -8,11 +8,11 @@ version = "0.3.3"
 
 [[Aqua]]
 deps = ["Pkg", "Test"]
-git-tree-sha1 = "ef5f638a83ec0099904ac1fe2cc254286e801a54"
+git-tree-sha1 = "41c0492682754f55c2564577c92bafb8968090e3"
 repo-rev = "master"
 repo-url = "https://github.com/JuliaTesting/Aqua.jl.git"
 uuid = "4c88cf16-eb10-579e-8560-4a9242c79595"
-version = "0.4.7"
+version = "0.5.0-DEV"
 
 [[ArgCheck]]
 git-tree-sha1 = "59c256cf71c3982484ae4486ee86a3d7da891dea"

--- a/test/environments/main/Project.toml
+++ b/test/environments/main/Project.toml
@@ -11,5 +11,5 @@ ThreadsX = "ac1d9e8a-700a-412c-b207-f0111f4b6c0d"
 Transducers = "28d57a85-8fef-5791-bfe6-a80928e7c999"
 
 [compat]
-Aqua = "0.4.7"
+Aqua = "0.5"
 Documenter = "0.24"

--- a/test/test_aqua.jl
+++ b/test/test_aqua.jl
@@ -6,14 +6,7 @@ using Test
 
 # Default `Aqua.test_all(ThreadsX)` does not work due to ambiguities
 # in upstream packages.
-Aqua.test_all(
-    ThreadsX;
-    ambiguities = false,
-    project_extras = true,
-    stale_deps = true,
-    deps_compat = true,
-    project_toml_formatting = true,
-)
+Aqua.test_all(ThreadsX; ambiguities = false)
 
 @testset "Method ambiguity" begin
     Aqua.test_ambiguities(ThreadsX)


### PR DESCRIPTION
- [x] Release https://github.com/JuliaTesting/Aqua.jl/pull/36

## Commit Message
Update to Aqua 0.5 (#155)

It simplifies `test_aqua.jl`.