### PR TITLE
Fix typo in `map` docstring

### DIFF
--- a/src/docs/map.md
+++ b/src/docs/map.md
@@ -1,4 +1,4 @@
-    ThreadsX.mapi(f, iterators...; basesize)
+    ThreadsX.map(f, iterators...; basesize)
 
 Parallelized `map(f, iterators...)`.  Input collections `iterators`
 must support `SplittablesBase.halve`


### PR DESCRIPTION
Looks to me like the docstring for `map` [here](https://tkf.github.io/ThreadsX.jl/dev/#ThreadsX.map) says "mapi" when it should be "map" in the function signature (?)